### PR TITLE
Add tokenURI

### DIFF
--- a/src/CreatorToken.sol
+++ b/src/CreatorToken.sol
@@ -24,6 +24,7 @@ contract CreatorToken is ERC721 {
   address public admin;
   address public immutable REFERRER;
   bool public isPaused;
+  string public tokenURI;
   IERC20 public payToken;
   IBondingCurve public immutable BONDING_CURVE;
 
@@ -69,6 +70,7 @@ contract CreatorToken is ERC721 {
   constructor(
     string memory _name,
     string memory _symbol,
+    string memory _tokenURI,
     address _creator,
     uint256 _creatorFee,
     address _admin,
@@ -80,6 +82,7 @@ contract CreatorToken is ERC721 {
     if (_creatorFee > MAX_FEE) revert CreatorToken__MaxFeeExceeded(_creatorFee, MAX_FEE);
     if (_adminFee > MAX_FEE) revert CreatorToken__MaxFeeExceeded(_adminFee, MAX_FEE);
 
+    tokenURI = _tokenURI;
     creator = _creator;
     CREATOR_FEE_BIPS = _creatorFee;
     admin = _admin;
@@ -116,6 +119,10 @@ contract CreatorToken is ERC721 {
   function updateAdmin(address _newAdmin) public isNotAddressZero(_newAdmin) {
     if (msg.sender != admin) revert CreatorToken__Unauthorized("not admin", msg.sender);
     admin = _newAdmin;
+  }
+
+  function updateTokenURI(string memory _newTokenURI) public onlyCreatorOrAdmin(msg.sender) {
+    tokenURI = _newTokenURI;
   }
 
   function _buy(address _to, uint256 _maxPayment) internal whenNotPaused {

--- a/src/CreatorToken.sol
+++ b/src/CreatorToken.sol
@@ -24,7 +24,7 @@ contract CreatorToken is ERC721 {
   address public admin;
   address public immutable REFERRER;
   bool public isPaused;
-  string public tokenURI;
+  string private creatorTokenURI;
   IERC20 public payToken;
   IBondingCurve public immutable BONDING_CURVE;
 
@@ -82,7 +82,7 @@ contract CreatorToken is ERC721 {
     if (_creatorFee > MAX_FEE) revert CreatorToken__MaxFeeExceeded(_creatorFee, MAX_FEE);
     if (_adminFee > MAX_FEE) revert CreatorToken__MaxFeeExceeded(_adminFee, MAX_FEE);
 
-    tokenURI = _tokenURI;
+    creatorTokenURI = _tokenURI;
     creator = _creator;
     CREATOR_FEE_BIPS = _creatorFee;
     admin = _admin;
@@ -121,8 +121,12 @@ contract CreatorToken is ERC721 {
     admin = _newAdmin;
   }
 
+  function tokenURI(uint256) public view override returns (string memory) {
+    return creatorTokenURI;
+  }
+
   function updateTokenURI(string memory _newTokenURI) public onlyCreatorOrAdmin(msg.sender) {
-    tokenURI = _newTokenURI;
+    creatorTokenURI = _newTokenURI;
   }
 
   function _buy(address _to, uint256 _maxPayment) internal whenNotPaused {

--- a/test/CreatorToken.t.sol
+++ b/test/CreatorToken.t.sol
@@ -168,14 +168,16 @@ contract Deployment is CreatorTokenTest {
     new CreatorToken(CREATOR_TOKEN_NAME, CREATOR_TOKEN_SYMBOL, CREATOR_TOKEN_URI, creator, CREATOR_FEE, admin, _adminFee, referrer, payToken, bondingCurve);
   }
 
-  function test_FirstTokenIsMintedToCreator() public {
+  function test_FirstTokensAreMintedCorrectly() public {
+    bool _isThereAReferrer = referrer != address(0);
+
     assertEq(creatorToken.balanceOf(creator), 1);
     assertEq(creatorToken.ownerOf(1), creator);
-  }
 
-  function test_SecondTokenIsMintedToReferrer() public {
-    assertEq(creatorToken.balanceOf(referrer), 1);
-    assertEq(creatorToken.ownerOf(2), referrer);
+    if (_isThereAReferrer) {
+      assertEq(creatorToken.balanceOf(referrer), 1);
+      assertEq(creatorToken.ownerOf(2), referrer);
+    }
   }
 }
 
@@ -304,6 +306,7 @@ contract Selling is CreatorTokenTest {
   function test_RevertIf_SellerIsNotTokenOwner(address _owner, address _seller) public {
     _assumeSafeBuyer(_seller);
     buyAToken(_owner);
+    vm.assume(_owner != _seller);
 
     uint256 _tokenId = creatorToken.lastId();
 

--- a/test/CreatorToken.t.sol
+++ b/test/CreatorToken.t.sol
@@ -122,7 +122,7 @@ contract Deployment is CreatorTokenTest {
   function test_TokenIsConfiguredAtDeployment() public {
     assertEq(creatorToken.name(), CREATOR_TOKEN_NAME);
     assertEq(creatorToken.symbol(), CREATOR_TOKEN_SYMBOL);
-    assertEq(creatorToken.tokenURI(), CREATOR_TOKEN_URI);
+    assertEq(creatorToken.tokenURI(1), CREATOR_TOKEN_URI);
     assertEq(creatorToken.creator(), creator);
     assertEq(creatorToken.CREATOR_FEE_BIPS(), CREATOR_FEE);
     assertEq(creatorToken.admin(), admin);
@@ -567,14 +567,14 @@ contract UpdatingBaseURI is CreatorTokenTest {
     string memory _newBaseURI = "https://newURI.com/metadata/";
     vm.prank(creator);
     creatorToken.updateTokenURI(_newBaseURI);
-    assertEq(creatorToken.tokenURI(), _newBaseURI);
+    assertEq(creatorToken.tokenURI(1), _newBaseURI);
   }
 
   function test_AdminCanUpdateBaseURI() public {
     string memory _newBaseURI = "https://newURI.com/metadata/";
     vm.prank(admin);
     creatorToken.updateTokenURI(_newBaseURI);
-    assertEq(creatorToken.tokenURI(), _newBaseURI);
+    assertEq(creatorToken.tokenURI(1), _newBaseURI);
   }
 
   function test_RevertIf_CallerIsNotCreatorOrAdmin(address _caller) public {


### PR DESCRIPTION
closes #16 , #17 

Went with standard ERC721 `baseURI+TokenId` as `TokenURI` approach. If needed, it's easy to make a single `tokenURI` that will be the same for all tokens.