### PR TITLE
Add `bulkBuy` 

### DIFF
--- a/src/CreatorToken.sol
+++ b/src/CreatorToken.sol
@@ -211,21 +211,6 @@ contract CreatorToken is ERC721 {
     (_creatorFee, _adminFee) = calculateFees(_tokenPrice);
   }
 
-  function priceForTokenId(uint256 _tokenId)
-    public
-    view
-    returns (uint256 _tokenPrice, uint256 _creatorFee, uint256 _adminFee)
-  {
-    if (_tokenId >= lastId) {
-      _tokenPrice =
-        BONDING_CURVE.priceForTokenNumber(totalSupply - _preMintOffset() + (_tokenId - lastId));
-    } else {
-      _tokenPrice =
-        BONDING_CURVE.priceForTokenNumber(totalSupply - _preMintOffset() + (lastId - _tokenId));
-    }
-    (_creatorFee, _adminFee) = calculateFees(_tokenPrice);
-  }
-
   function calculateFees(uint256 _price)
     public
     view

--- a/src/CreatorToken.sol
+++ b/src/CreatorToken.sol
@@ -98,23 +98,25 @@ contract CreatorToken is ERC721 {
     if (_referrer != address(0)) _mintAndIncrement(_referrer);
   }
 
-  function buy(uint256 _maxPayment) public {
-    buy(msg.sender, _maxPayment);
+  function buy(uint256 _maxPayment) public returns (uint256 _totalPrice) {
+    _totalPrice = buy(msg.sender, _maxPayment);
   }
 
-  function buy(address _to, uint256 _maxPayment) public {
-    uint256 _totalPrice = _buy(_to);
+  function buy(address _to, uint256 _maxPayment) public returns (uint256 _totalPrice) {
+    _totalPrice = _buy(_to);
     if (_totalPrice > _maxPayment) {
       revert CreatorToken__MaxPaymentExceeded(_totalPrice, _maxPayment);
     }
   }
 
-  function bulkBuy(uint256 _numOfTokens, uint256 _maxPayment) public {
-    bulkBuy(msg.sender, _numOfTokens, _maxPayment);
+  function bulkBuy(uint256 _numOfTokens, uint256 _maxPayment) public returns (uint256 _totalPrice) {
+    _totalPrice = bulkBuy(msg.sender, _numOfTokens, _maxPayment);
   }
 
-  function bulkBuy(address _to, uint256 _numOfTokens, uint256 _maxPayment) public {
-    uint256 _totalPrice;
+  function bulkBuy(address _to, uint256 _numOfTokens, uint256 _maxPayment)
+    public
+    returns (uint256 _totalPrice)
+  {
     for (uint256 _i = 0; _i < _numOfTokens; _i++) {
       _totalPrice += _buy(_to);
     }

--- a/test/CreatorToken.t.sol
+++ b/test/CreatorToken.t.sol
@@ -242,6 +242,58 @@ abstract contract Buying is CreatorTokenTest {
     vm.stopPrank();
   }
 
+  function test_BulkBuy(address _buyer, uint256 _numTokensToBuy) public {
+    _assumeSafeBuyer(_buyer);
+    _numTokensToBuy = bound(_numTokensToBuy, 1, 100);
+
+    uint256 _originalPayTokenBalanceOfCreatorTokenContract =
+      payToken.balanceOf(address(creatorToken));
+    uint256 _originalBuyerBalanceOfCreatorTokens = creatorToken.balanceOf(_buyer);
+    uint256 _originalCreatorTokenSupply = creatorToken.totalSupply();
+    uint256 _originalPayTokenBalanceOfBuyer = payToken.balanceOf(_buyer);
+    uint256 _originalPayTokenBalanceOfCreator = payToken.balanceOf(creator);
+    uint256 _originalPayTokenBalanceOfAdmin = payToken.balanceOf(admin);
+
+    uint256 _expectedPayTokenAddedToContract;
+    uint256 _expectedTotalPricePaidByBuyer;
+    uint256 _expectedPayTokenEarnedByCreator;
+    uint256 _expectedPayTokenEarnedByAdmin;
+
+    for (uint256 _i = 1; _i <= _numTokensToBuy; _i++) {
+      (uint256 _tokenPrice, uint256 _creatorFee, uint256 _adminFee) =
+        creatorToken.priceForTokenId(creatorToken.totalSupply() + _i);
+      uint256 _totalPrice = _tokenPrice + _creatorFee + _adminFee;
+      _expectedPayTokenAddedToContract += _tokenPrice;
+      _expectedTotalPricePaidByBuyer += _totalPrice;
+      _expectedPayTokenEarnedByCreator += _creatorFee;
+      _expectedPayTokenEarnedByAdmin += _adminFee;
+    }
+
+    deal(address(payToken), _buyer, _expectedTotalPricePaidByBuyer);
+    vm.startPrank(_buyer);
+    payToken.approve(address(creatorToken), type(uint256).max);
+    creatorToken.bulkBuy(_numTokensToBuy, _expectedTotalPricePaidByBuyer);
+    vm.stopPrank();
+
+    for (uint256 _i; _i < _numTokensToBuy; _i++) {
+      assertEq(creatorToken.ownerOf(creatorToken.lastId() - _i), _buyer);
+    }
+    assertEq(creatorToken.balanceOf(_buyer), _originalBuyerBalanceOfCreatorTokens + _numTokensToBuy);
+    assertEq(
+      payToken.balanceOf(address(creatorToken)),
+      _originalPayTokenBalanceOfCreatorTokenContract + _expectedPayTokenAddedToContract
+    );
+    assertEq(payToken.balanceOf(_buyer), _originalPayTokenBalanceOfBuyer);
+    assertEq(creatorToken.totalSupply(), _originalCreatorTokenSupply + _numTokensToBuy);
+    assertEq(
+      payToken.balanceOf(creator),
+      _originalPayTokenBalanceOfCreator + _expectedPayTokenEarnedByCreator
+    );
+    assertEq(
+      payToken.balanceOf(admin), _originalPayTokenBalanceOfAdmin + _expectedPayTokenEarnedByAdmin
+    );
+  }
+
   function test_RevertIf_PriceExceedsMaxPayment(address _buyer, uint256 _maxPayment) public {
     vm.assume(_buyer != address(0) && _buyer != address(creatorToken));
 
@@ -583,6 +635,16 @@ abstract contract CreatorTokenFollowsBondingCurveContract is CreatorTokenTest {
       assertEq(_adminFee, _adminFeeCalculatedWithBondingCurveTokenPrice);
       sellAToken(_seller, _tokenIds[_i]);
     }
+  }
+
+  function test_PriceForTokenIdIsCorrect(uint256 _tokenId) public {
+    uint256 _preMintOffset = referrer == address(0) ? 1 : 2;
+    _tokenId = bound(_tokenId, _preMintOffset + 1, 1000);
+
+    (uint256 _tokenPrice,,) = creatorToken.priceForTokenId(_tokenId);
+    uint256 _expectedTokenPrice = bondingCurve.priceForTokenNumber(_tokenId - _preMintOffset);
+
+    assertEq(_tokenPrice, _expectedTokenPrice);
   }
 }
 

--- a/test/CreatorToken.t.sol
+++ b/test/CreatorToken.t.sol
@@ -594,6 +594,12 @@ abstract contract CreatorTokenFollowsBondingCurveContract is CreatorTokenTest {
 
     for (uint256 _i = 0; _i < _numTokensToBuy; _i++) {
       (uint256 _tokenPrice, uint256 _creatorFee, uint256 _adminFee) = creatorToken.nextBuyPrice();
+      (
+        uint256 _tokenPriceFromPriceForTokenId,
+        uint256 _creatorFeeFromPriceForTokenId,
+        uint256 _adminFeeFromPriceForTokenId
+      ) = creatorToken.priceForTokenId(creatorToken.totalSupply() + 1);
+
       uint256 _preMintOffset = referrer == address(0) ? 1 : 2;
       uint256 _bondingCurveTokenPrice =
         bondingCurve.priceForTokenNumber((creatorToken.totalSupply() + 1) - _preMintOffset);
@@ -605,6 +611,9 @@ abstract contract CreatorTokenFollowsBondingCurveContract is CreatorTokenTest {
       assertEq(_tokenPrice, _bondingCurveTokenPrice);
       assertEq(_creatorFee, _creatorFeeCalculatedWithBondingCurveTokenPrice);
       assertEq(_adminFee, _adminFeeCalculatedWithBondingCurveTokenPrice);
+      assertEq(_tokenPrice, _tokenPriceFromPriceForTokenId);
+      assertEq(_creatorFee, _creatorFeeFromPriceForTokenId);
+      assertEq(_adminFee, _adminFeeFromPriceForTokenId);
       buyAToken(_buyer);
     }
   }
@@ -622,6 +631,12 @@ abstract contract CreatorTokenFollowsBondingCurveContract is CreatorTokenTest {
     // sell n tokens
     for (uint256 _i = 0; _i < _numTokensToBuyAndSell; _i++) {
       (uint256 _tokenPrice, uint256 _creatorFee, uint256 _adminFee) = creatorToken.nextSellPrice();
+      (
+        uint256 _tokenPriceFromPriceForTokenId,
+        uint256 _creatorFeeFromPriceForTokenId,
+        uint256 _adminFeeFromPriceForTokenId
+      ) = creatorToken.priceForTokenId(creatorToken.totalSupply());
+
       uint256 _preMintOffset = referrer == address(0) ? 1 : 2;
       uint256 _bondingCurveTokenPrice =
         bondingCurve.priceForTokenNumber(creatorToken.totalSupply() - _preMintOffset);
@@ -633,6 +648,9 @@ abstract contract CreatorTokenFollowsBondingCurveContract is CreatorTokenTest {
       assertEq(_tokenPrice, _bondingCurveTokenPrice);
       assertEq(_creatorFee, _creatorFeeCalculatedWithBondingCurveTokenPrice);
       assertEq(_adminFee, _adminFeeCalculatedWithBondingCurveTokenPrice);
+      assertEq(_tokenPrice, _tokenPriceFromPriceForTokenId);
+      assertEq(_creatorFee, _creatorFeeFromPriceForTokenId);
+      assertEq(_adminFee, _adminFeeFromPriceForTokenId);
       sellAToken(_seller, _tokenIds[_i]);
     }
   }

--- a/test/CreatorToken.t.sol
+++ b/test/CreatorToken.t.sol
@@ -259,9 +259,12 @@ abstract contract Buying is CreatorTokenTest {
     uint256 _expectedPayTokenEarnedByCreator;
     uint256 _expectedPayTokenEarnedByAdmin;
 
+    uint256 _preMintOffset = referrer == address(0) ? 1 : 2;
+
     for (uint256 _i = 1; _i <= _numTokensToBuy; _i++) {
-      (uint256 _tokenPrice, uint256 _creatorFee, uint256 _adminFee) =
-        creatorToken.priceForTokenId(creatorToken.totalSupply() + _i);
+      (uint256 _tokenPrice) =
+        bondingCurve.priceForTokenNumber((creatorToken.totalSupply() + _i) - _preMintOffset);
+      (uint256 _creatorFee, uint256 _adminFee) = creatorToken.calculateFees(_tokenPrice);
       uint256 _totalPrice = _tokenPrice + _creatorFee + _adminFee;
       _expectedPayTokenAddedToContract += _tokenPrice;
       _expectedTotalPricePaidByBuyer += _totalPrice;
@@ -318,8 +321,10 @@ abstract contract Buying is CreatorTokenTest {
     uint256 _expectedPayTokenEarnedByAdmin;
 
     for (uint256 _i = 1; _i <= _numTokensToBuy; _i++) {
-      (uint256 _tokenPrice, uint256 _creatorFee, uint256 _adminFee) =
-        creatorToken.priceForTokenId(creatorToken.totalSupply() + _i);
+      (uint256 _tokenPrice) = bondingCurve.priceForTokenNumber(
+        (creatorToken.totalSupply() + _i) - (referrer == address(0) ? 1 : 2)
+      );
+      (uint256 _creatorFee, uint256 _adminFee) = creatorToken.calculateFees(_tokenPrice);
       uint256 _totalPrice = _tokenPrice + _creatorFee + _adminFee;
       _expectedPayTokenAddedToContract += _tokenPrice;
       _expectedTotalPricePaidByBuyer += _totalPrice;
@@ -381,10 +386,12 @@ abstract contract Buying is CreatorTokenTest {
     _numTokensToBuy = bound(_numTokensToBuy, 1, 100);
 
     uint256 _expectedTotalPricePaidByBuyer;
+    uint256 _preMintOffset = referrer == address(0) ? 1 : 2;
 
     for (uint256 _i = 1; _i <= _numTokensToBuy; _i++) {
-      (uint256 _tokenPrice, uint256 _creatorFee, uint256 _adminFee) =
-        creatorToken.priceForTokenId(creatorToken.totalSupply() + _i);
+      (uint256 _tokenPrice) =
+        bondingCurve.priceForTokenNumber((creatorToken.totalSupply() + _i) - _preMintOffset);
+      (uint256 _creatorFee, uint256 _adminFee) = creatorToken.calculateFees(_tokenPrice);
       uint256 _totalPrice = _tokenPrice + _creatorFee + _adminFee;
       _expectedTotalPricePaidByBuyer += _totalPrice;
     }

--- a/test/CreatorToken.t.sol
+++ b/test/CreatorToken.t.sol
@@ -262,6 +262,8 @@ abstract contract Buying is CreatorTokenTest {
     uint256 _preMintOffset = referrer == address(0) ? 1 : 2;
 
     for (uint256 _i = 1; _i <= _numTokensToBuy; _i++) {
+      // Determine the total expected payment by asking the bonding curve for token price and
+      // calculating the fees manually.
       (uint256 _tokenPrice) =
         bondingCurve.priceForTokenNumber((creatorToken.totalSupply() + _i) - _preMintOffset);
       (uint256 _creatorFee, uint256 _adminFee) = creatorToken.calculateFees(_tokenPrice);
@@ -321,6 +323,8 @@ abstract contract Buying is CreatorTokenTest {
     uint256 _expectedPayTokenEarnedByAdmin;
 
     for (uint256 _i = 1; _i <= _numTokensToBuy; _i++) {
+      // Determine the total expected payment by asking the bonding curve for token price and
+      // calculating the fees manually.
       (uint256 _tokenPrice) = bondingCurve.priceForTokenNumber(
         (creatorToken.totalSupply() + _i) - (referrer == address(0) ? 1 : 2)
       );

--- a/test/CreatorToken.t.sol
+++ b/test/CreatorToken.t.sol
@@ -654,11 +654,6 @@ abstract contract CreatorTokenFollowsBondingCurveContract is CreatorTokenTest {
 
     for (uint256 _i = 0; _i < _numTokensToBuy; _i++) {
       (uint256 _tokenPrice, uint256 _creatorFee, uint256 _adminFee) = creatorToken.nextBuyPrice();
-      (
-        uint256 _tokenPriceFromPriceForTokenId,
-        uint256 _creatorFeeFromPriceForTokenId,
-        uint256 _adminFeeFromPriceForTokenId
-      ) = creatorToken.priceForTokenId(creatorToken.totalSupply() + 1);
 
       uint256 _preMintOffset = referrer == address(0) ? 1 : 2;
       uint256 _bondingCurveTokenPrice =
@@ -671,9 +666,6 @@ abstract contract CreatorTokenFollowsBondingCurveContract is CreatorTokenTest {
       assertEq(_tokenPrice, _bondingCurveTokenPrice);
       assertEq(_creatorFee, _creatorFeeCalculatedWithBondingCurveTokenPrice);
       assertEq(_adminFee, _adminFeeCalculatedWithBondingCurveTokenPrice);
-      assertEq(_tokenPrice, _tokenPriceFromPriceForTokenId);
-      assertEq(_creatorFee, _creatorFeeFromPriceForTokenId);
-      assertEq(_adminFee, _adminFeeFromPriceForTokenId);
       buyAToken(_buyer);
     }
   }
@@ -691,11 +683,6 @@ abstract contract CreatorTokenFollowsBondingCurveContract is CreatorTokenTest {
     // sell n tokens
     for (uint256 _i = 0; _i < _numTokensToBuyAndSell; _i++) {
       (uint256 _tokenPrice, uint256 _creatorFee, uint256 _adminFee) = creatorToken.nextSellPrice();
-      (
-        uint256 _tokenPriceFromPriceForTokenId,
-        uint256 _creatorFeeFromPriceForTokenId,
-        uint256 _adminFeeFromPriceForTokenId
-      ) = creatorToken.priceForTokenId(_tokenIds[_i]);
 
       uint256 _preMintOffset = referrer == address(0) ? 1 : 2;
       uint256 _bondingCurveTokenPrice =
@@ -708,69 +695,8 @@ abstract contract CreatorTokenFollowsBondingCurveContract is CreatorTokenTest {
       assertEq(_tokenPrice, _bondingCurveTokenPrice);
       assertEq(_creatorFee, _creatorFeeCalculatedWithBondingCurveTokenPrice);
       assertEq(_adminFee, _adminFeeCalculatedWithBondingCurveTokenPrice);
-      assertEq(_tokenPrice, _tokenPriceFromPriceForTokenId);
-      assertEq(_creatorFee, _creatorFeeFromPriceForTokenId);
-      assertEq(_adminFee, _adminFeeFromPriceForTokenId);
       sellAToken(_seller, _tokenIds[_i]);
     }
-  }
-
-  function test_PriceForTokenIdIsCorrect(uint256 _tokenId) public {
-    uint256 _preMintOffset = referrer == address(0) ? 1 : 2;
-    _tokenId = bound(_tokenId, _preMintOffset + 1, 1000);
-
-    (uint256 _tokenPrice,,) = creatorToken.priceForTokenId(_tokenId);
-    uint256 _expectedTokenPrice = bondingCurve.priceForTokenNumber(_tokenId - _preMintOffset);
-
-    assertEq(_tokenPrice, _expectedTokenPrice);
-  }
-
-  function test_PriceForTokenIdIsCorrectAfterBurn(
-    address _buyer,
-    uint256 _tokenId,
-    uint256 _numTokensToBuy,
-    uint256 _numTokensToSell
-  ) public {
-    _assumeSafeBuyer(_buyer);
-    uint256 _preMintOffset = referrer == address(0) ? 1 : 2;
-    _tokenId = bound(_tokenId, _preMintOffset + 1, 1000);
-    _numTokensToBuy = bound(_numTokensToBuy, 2, 100);
-    _numTokensToSell = bound(_numTokensToSell, 1, _numTokensToBuy);
-
-    for (uint256 _i = 0; _i < _numTokensToBuy; _i++) {
-      (uint256 _tokenBuyPriceBeforeBuy,,) = creatorToken.priceForTokenId(creatorToken.lastId() + 1);
-      (uint256 _tokenSellPriceBeforeBuy,,) = creatorToken.priceForTokenId(creatorToken.lastId());
-      (uint256 _expectedTokenPriceBeforeBuy,,) = creatorToken.nextBuyPrice();
-      (uint256 _expectedTokenSellBeforeBuy,,) = creatorToken.nextSellPrice();
-      console2.log(_expectedTokenSellBeforeBuy, "_expectedTokenSellBeforeBuy");
-
-      assertEq(_tokenBuyPriceBeforeBuy, _expectedTokenPriceBeforeBuy);
-      assertEq(_tokenSellPriceBeforeBuy, _expectedTokenSellBeforeBuy);
-
-      buyAToken(_buyer);
-    }
-    for (uint256 _i = 0; _i < _numTokensToSell; _i++) {
-      (uint256 _tokenBuyPriceBeforeSell,,) = creatorToken.priceForTokenId(creatorToken.lastId() + 1);
-      (uint256 _tokenSellPriceBeforeSell,,) =
-        creatorToken.priceForTokenId(creatorToken.lastId() - _i);
-      (uint256 _expectedTokenPriceBeforeSell,,) = creatorToken.nextBuyPrice();
-      (uint256 _expectedTokenSellBeforeSell,,) = creatorToken.nextSellPrice();
-
-      assertEq(_tokenBuyPriceBeforeSell, _expectedTokenPriceBeforeSell);
-      assertEq(_tokenSellPriceBeforeSell, _expectedTokenSellBeforeSell);
-
-      sellAToken(_buyer, creatorToken.lastId() - _i);
-    }
-
-    (uint256 _tokenBuyPrice,,) = creatorToken.priceForTokenId(creatorToken.lastId() + 1);
-    (uint256 _tokenSellPrice,,) = creatorToken.priceForTokenId(creatorToken.lastId()); // Don't
-      // think lastId is the correct param here
-
-    (uint256 _expectedTokenPrice,,) = creatorToken.nextBuyPrice();
-    (uint256 _expectedTokenSellPrice,,) = creatorToken.nextSellPrice();
-
-    assertEq(_tokenBuyPrice, _expectedTokenPrice);
-    assertEq(_tokenSellPrice, _expectedTokenSellPrice);
   }
 }
 


### PR DESCRIPTION
closes #27 


Questions lingering in my head:

1. is it fine that we use `type(uint256).max` here because we're eventually checking the total price against max payment anyways.
```
_totalPrice += _buy(msg.sender, type(uint256).max);
```

2. Look like we can simplify `nextBuyPrice` and `nextSellPrice` to use `priceForTokenId`, should we? 
3. Should `priceForTokenId` check if the `_tokenId` passed in is one of the pre-minted ids? And return 0 if they are.
4. Is the current `test_PriceForTokenIdIsCorrect` test sufficient? Or should we try another approach where we buy tokens up till `tokenId - 1` and then compare `priceForTokenId` results with `nextBuyPrice`
