### PR TITLE
Add `bulkSell` and tests

### DIFF
--- a/src/CreatorToken.sol
+++ b/src/CreatorToken.sol
@@ -125,8 +125,8 @@ contract CreatorToken is ERC721 {
     public
     returns (uint256 _netProceeds)
   {
-    for (uint256 i = 0; i < _tokenIds.length; i++) {
-      _netProceeds += _sell(_tokenIds[i]);
+    for (uint256 _i = 0; _i < _tokenIds.length; _i++) {
+      _netProceeds += _sell(_tokenIds[_i]);
     }
     if (_netProceeds < _minAcceptedPrice) {
       revert CreatorToken__MinAcceptedPriceExceeded(_netProceeds, _minAcceptedPrice);

--- a/test/CreatorToken.t.sol
+++ b/test/CreatorToken.t.sol
@@ -309,12 +309,15 @@ abstract contract Selling is CreatorTokenTest {
     for (uint256 _i = 0; _i < _numTokensToBuyAndSell; _i++) {
       buyAToken(_seller);
       (uint256 _tokenPrice, uint256 _creatorFee, uint256 _adminFee) = creatorToken.nextSellPrice();
-      _expectedNetProceeds += _tokenPrice - _creatorFee - _adminFee;
+      _expectedNetProceeds += (_tokenPrice - _creatorFee - _adminFee);
       _expectedPayTokenToBeEarnedByCreator += _creatorFee;
       _expectedPayTokenToBeEarnedByAdmin += _adminFee;
       _tokenIds[_i] = (creatorToken.lastId());
     }
-    require(creatorToken.balanceOf(_seller) == _numTokensToBuyAndSell);
+    require(
+      creatorToken.balanceOf(_seller) == _numTokensToBuyAndSell,
+      "Broken test invariant: seller does not own correct number of tokens to sell."
+    );
     uint256 _originalPayTokenBalanceOfSeller = payToken.balanceOf(_seller);
     uint256 _originalPayTokenBalanceOfCreator = payToken.balanceOf(creator);
     uint256 _originalPayTokenBalanceOfAdmin = payToken.balanceOf(admin);


### PR DESCRIPTION
closes #30 
In addition to adding `bulkSell` and corresponding tests, I

1. Moved the position of 
```    
uint256 _originalPayTokenBalanceOfBuyer = payToken.balanceOf(_buyer);
```
down below `deal` because `deal` sets a new balance instead of adding additional tokens.

2. Started adding a third string to `assertEq` in accordance with foundrybook [best practices](https://book.getfoundry.sh/tutorials/best-practices#general-test-guidance), which helped spot the issue described above.
![image](https://github.com/showtime-xyz/creator-tokens/assets/61768337/b7246c7e-8e11-47eb-9087-094fee1d56b0)
