### PR TITLE
Rename bonding curve and write bonding curve natspec docs

### DIFF
--- a/src/CreatorTokenFactory.sol
+++ b/src/CreatorTokenFactory.sol
@@ -2,7 +2,7 @@
 pragma solidity 0.8.20;
 
 import {CreatorToken} from "src/CreatorToken.sol";
-import {CTBondingCurve} from "src/CTBondingCurve.sol";
+import {SigmoidBondingCurve} from "src/SigmoidBondingCurve.sol";
 import {IERC20} from "openzeppelin/token/ERC20/IERC20.sol";
 import {IShowtimeVerifier, Attestation} from "src/lib/IShowtimeVerifier.sol";
 
@@ -26,7 +26,9 @@ contract CreatorTokenFactory {
   }
 
   event CreatorTokenDeployed(
-    CreatorToken indexed creatorToken, CTBondingCurve indexed bondingCurve, DeploymentConfig config
+    CreatorToken indexed creatorToken,
+    SigmoidBondingCurve indexed bondingCurve,
+    DeploymentConfig config
   );
 
   error CreatorTokenFactory__DeploymentNotVerified();
@@ -100,8 +102,8 @@ contract CreatorTokenFactory {
       revert CreatorTokenFactory__InvalidAttestation();
     }
 
-    CTBondingCurve _bondingCurve =
-    new CTBondingCurve(_config.basePrice, _config.linearPriceSlope, _config.inflectionPrice, _config.inflectionPoint);
+    SigmoidBondingCurve _bondingCurve =
+    new SigmoidBondingCurve(_config.basePrice, _config.linearPriceSlope, _config.inflectionPrice, _config.inflectionPoint);
 
     _creatorToken = new CreatorToken(
       _config.name,

--- a/src/SigmoidBondingCurve.sol
+++ b/src/SigmoidBondingCurve.sol
@@ -5,7 +5,7 @@ import {BondingCurveLib} from "src/lib/BondingCurveLib.sol";
 import {IBondingCurve} from "src/interfaces/IBondingCurve.sol";
 import {SafeCast} from "openzeppelin/utils/math/SafeCast.sol";
 
-contract CTBondingCurve is IBondingCurve {
+contract SigmoidBondingCurve is IBondingCurve {
   using SafeCast for uint256;
 
   uint128 public immutable BASE_PRICE;

--- a/src/SigmoidBondingCurve.sol
+++ b/src/SigmoidBondingCurve.sol
@@ -5,17 +5,51 @@ import {BondingCurveLib} from "src/lib/BondingCurveLib.sol";
 import {IBondingCurve} from "src/interfaces/IBondingCurve.sol";
 import {SafeCast} from "openzeppelin/utils/math/SafeCast.sol";
 
+/// @notice Concrete bonding curve implementation using a sigmoid consisting of a quadratic
+/// region and a square root region.
+///
+/// The quadratic region enables the price to increase rapidly when the holder pool is small. This
+/// encourages viral growth at the early stages. Once a certain number of NFTs are in circulation,
+/// the curve transitions to the square root region. This allows the price to increase at a slowing
+/// rate, which provides better price stability and marks the transition of an NFT into a
+/// "blue chip."
+///
+/// This bonding curve was implemented and audited for the Sound Swap protocol. This contract uses
+/// `BondingCurveLib.sol` from that project and conforms to the interface expected for a Creator
+/// token bonding curve.
+///
+/// Read more about Sound Swap bonding curve implementation here:
+/// https://sound.mirror.xyz/rPnld1tfPFb3OxtfztRSjTFjc9KLUqmcV2DPCO68KMQ
 contract SigmoidBondingCurve is IBondingCurve {
   using SafeCast for uint256;
 
+  /// @notice The base price at the start of the curve.
   uint128 public immutable BASE_PRICE;
+
+  /// @notice The linear coefficient used to fine tune the curve.
   uint128 public immutable LINEAR_PRICE_SLOPE;
+
+  /// @notice The price at the point where the curve switches from quadratic to square root.
   uint128 public immutable INFLECTION_PRICE;
+
+  /// @notice Where the curve switches from quadratic to square root.
   uint32 public immutable INFLECTION_POINT;
 
-  // TODO: documentation should make clear the expectation that inflection price,
-  // which will be in the token's raw decimals, must be much greater than the
-  // inflection point for this math to produce correct results in the quadratic section.
+  /// @param _basePrice The base price at the start of the curve.
+  /// @param _linearPriceSlope The linear coefficient used to fine tune the curve.
+  /// @param _inflectionPrice The price at the point where the curve switches from quadratic to
+  /// square root.
+  /// @param _inflectionPoint Where the curve switches from quadratic to square root.
+  /// @dev The inflection point is along the curve's x-axis, that is, the number of tokens. The
+  /// other parameters are along the curve's y-axis, that is, the price. The price parameters must
+  /// be in the decimals of the payment token, for example, `1e6` for USDC or `1e18` for ETH.
+  ///
+  /// The math used in the bonding curve library assumes that the raw value for inflection price
+  /// will be much greater than the inflection point. This assumption should hold for most expected
+  /// values because the price is token decimals. For example, an inflection price of 30 USDC at an
+  /// inflection point of 50 tokens would mean 30e6 >> 50. If this assumption does not hold, either
+  /// because the raw value of the inflection price is very low, or the inflection point is very
+  /// high, this contract will not produce correct results.
   constructor(
     uint128 _basePrice,
     uint128 _linearPriceSlope,
@@ -28,6 +62,7 @@ contract SigmoidBondingCurve is IBondingCurve {
     INFLECTION_POINT = _inflectionPoint;
   }
 
+  /// @dev See {IBondingCurve-priceForTokenNumber}
   function priceForTokenNumber(uint256 _tokenNumber) external view returns (uint256 _price) {
     uint32 _currentSupply = _tokenNumber.toUint32() - 1;
 

--- a/src/interfaces/IBondingCurve.sol
+++ b/src/interfaces/IBondingCurve.sol
@@ -1,6 +1,15 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.20;
 
+/// @notice The interface a contract must implement to function as a bonding curve for a
+/// CreatorToken contract.
 interface IBondingCurve {
+  /// @notice View method that returns the price to purchase the Nth token as derived by a given
+  /// bonding curve implementation.
+  /// @param _tokenNumber The Nth token for which we want to derive the price to buy or sell.
+  /// @return _price The price of the Nth token as derived by the bonding curve implementation.
+  /// @dev It is assumed that the number returned is deterministic, and will not vary over time.
+  /// A bonding curve that returned different values, given the same argument for `_tokenNumber`,
+  /// would break a critical invariant of the CreatorToken contract.
   function priceForTokenNumber(uint256 _tokenNumber) external view returns (uint256 _price);
 }

--- a/test/CreatorTokenFactory.t.sol
+++ b/test/CreatorTokenFactory.t.sol
@@ -3,7 +3,7 @@ pragma solidity 0.8.20;
 
 import {Test, console2} from "forge-std/Test.sol";
 import {CreatorToken} from "src/CreatorToken.sol";
-import {CTBondingCurve} from "src/CTBondingCurve.sol";
+import {SigmoidBondingCurve} from "src/SigmoidBondingCurve.sol";
 import {IERC20, ERC20} from "openzeppelin/token/ERC20/ERC20.sol";
 import {CreatorTokenFactory, Attestation} from "src/CreatorTokenFactory.sol";
 import {
@@ -31,7 +31,7 @@ contract CreatorTokenFactoryTest is Test {
 
   event CreatorTokenDeployed(
     CreatorToken indexed creatorToken,
-    CTBondingCurve indexed bondingCurve,
+    SigmoidBondingCurve indexed bondingCurve,
     CreatorTokenFactory.DeploymentConfig config
   );
 
@@ -90,7 +90,7 @@ contract CreatorTokenFactoryTest is Test {
     assertEq(_creatorToken.REFERRER(), _config.referrer);
     assertEq(address(_creatorToken.payToken()), address(_config.payToken));
 
-    CTBondingCurve _bondingCurve = CTBondingCurve(address(_creatorToken.BONDING_CURVE()));
+    SigmoidBondingCurve _bondingCurve = SigmoidBondingCurve(address(_creatorToken.BONDING_CURVE()));
     assertEq(_bondingCurve.BASE_PRICE(), _config.basePrice);
     assertEq(_bondingCurve.INFLECTION_POINT(), _config.inflectionPoint);
     assertEq(_bondingCurve.INFLECTION_PRICE(), _config.inflectionPrice);
@@ -154,8 +154,8 @@ contract TokenDeployment is CreatorTokenFactoryTest {
     // hardcoded, pre-calculated addresses for the test config, so we can expect the event emissions
     CreatorToken preCalculatedTokenAddress =
       CreatorToken(0x037eDa3aDB1198021A9b2e88C22B464fD38db3f3);
-    CTBondingCurve preCalculatedBondingCurve =
-      CTBondingCurve(0x104fBc016F4bb334D775a19E8A6510109AC63E00);
+    SigmoidBondingCurve preCalculatedBondingCurve =
+      SigmoidBondingCurve(0x104fBc016F4bb334D775a19E8A6510109AC63E00);
 
     vm.expectEmit(true, true, true, true);
     emit CreatorTokenDeployed(preCalculatedTokenAddress, preCalculatedBondingCurve, _config);

--- a/test/SigmoidBondingCurve.t.sol
+++ b/test/SigmoidBondingCurve.t.sol
@@ -2,21 +2,21 @@
 pragma solidity 0.8.20;
 
 import {Test, console2} from "forge-std/Test.sol";
-import {CTBondingCurve} from "src/CTBondingCurve.sol";
+import {SigmoidBondingCurve} from "src/SigmoidBondingCurve.sol";
 
-contract CTBondingCurveTest is Test {
+contract SigmoidBondingCurveTest is Test {
   function setUp() public {}
 }
 
-contract Deployment is CTBondingCurveTest {
+contract Deployment is SigmoidBondingCurveTest {
   function test_BondingCurveIsConfiguredAtDeployment(
     uint128 _basePrice,
     uint128 _linearPriceSlope,
     uint128 _inflectionPrice,
     uint32 _inflectionPoint
   ) public {
-    CTBondingCurve _curve =
-      new CTBondingCurve(_basePrice, _linearPriceSlope, _inflectionPrice, _inflectionPoint);
+    SigmoidBondingCurve _curve =
+      new SigmoidBondingCurve(_basePrice, _linearPriceSlope, _inflectionPrice, _inflectionPoint);
 
     assertEq(_curve.BASE_PRICE(), _basePrice);
     assertEq(_curve.LINEAR_PRICE_SLOPE(), _linearPriceSlope);
@@ -25,15 +25,15 @@ contract Deployment is CTBondingCurveTest {
   }
 }
 
-contract CurveMath is CTBondingCurveTest {
+contract CurveMath is SigmoidBondingCurveTest {
   function test_DiscreetCurveParametersWorkAsExpectedRev1() public {
     // Price parameters are in 6 decimals e.g. like USDC
     uint128 _basePrice = 1e6; // c = 1
     uint128 _linearPriceSlope = 0.1e6; // b = .1
     uint128 _inflectionPrice = 845e6; // h = 845
     uint32 _inflectionPoint = 2000; // g = 2000
-    CTBondingCurve _curve =
-      new CTBondingCurve(_basePrice, _linearPriceSlope, _inflectionPrice, _inflectionPoint);
+    SigmoidBondingCurve _curve =
+      new SigmoidBondingCurve(_basePrice, _linearPriceSlope, _inflectionPrice, _inflectionPoint);
 
     // Pre-calculated expectations, see https://www.desmos.com/calculator/tmeotsiwyi for the
     // curve calculations used to validate these
@@ -58,8 +58,8 @@ contract CurveMath is CTBondingCurveTest {
     uint128 _linearPriceSlope = 2e18; // b = 2
     uint128 _inflectionPrice = 1200e18; // h = 1200
     uint32 _inflectionPoint = 10_000; // g = 10000
-    CTBondingCurve _curve =
-      new CTBondingCurve(_basePrice, _linearPriceSlope, _inflectionPrice, _inflectionPoint);
+    SigmoidBondingCurve _curve =
+      new SigmoidBondingCurve(_basePrice, _linearPriceSlope, _inflectionPrice, _inflectionPoint);
 
     // Pre-calculated expectations
     assertEq(_curve.priceForTokenNumber(1), 5_000_012_000_000_000_000);
@@ -86,8 +86,8 @@ contract CurveMath is CTBondingCurveTest {
     uint128 _inflectionPrice = 44e6; // h = 44 USDC
     uint32 _inflectionPoint = 50; // g = 50 tokens
 
-    CTBondingCurve _curve =
-      new CTBondingCurve(_basePrice, _linearPriceSlope, _inflectionPrice, _inflectionPoint);
+    SigmoidBondingCurve _curve =
+      new SigmoidBondingCurve(_basePrice, _linearPriceSlope, _inflectionPrice, _inflectionPoint);
 
     // forgefmt: disable-start
     assertEq(_curve.priceForTokenNumber(1), 1_017_600);// 1st    token is  $1.0176


### PR DESCRIPTION
As I was working through the docs, I realized `CTBondingCurve` was in inconsistent and non-descriptive name, since elsewhere we use `CreatorToken` as the prefix, and the name doesn't describe the kind of bonding curve being implemented. I renamed to `SigmoidBondingCurve` and wrote the docs to go along with it.